### PR TITLE
Change HTTP to HTTPS

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -39,7 +39,7 @@ function searchSong(lyrics, artist) {
         format: "jsonp",
         callback: "jsonp_callback",
       },
-      url: "http://api.musixmatch.com/ws/1.1/track.search?page_size=10&page=1&s_track_rating=desc",
+      url: "https://api.musixmatch.com/ws/1.1/track.search?page_size=10&page=1&s_track_rating=desc",
       dataType: "jsonp",
       jsonpCallback: "jsonp_callback",
       contentType: "application/json",


### PR DESCRIPTION
Getting "mixed content" error on deployed app (but not in VSCode Live Server). Hopefully this fixes it.

`Blocked loading mixed active content “http://api.musixmatch.com/ws/1.1/track.search?page_size=10&page=1&s_track_rating=desc&callback=jsonp_callback&apikey=5fad2ed714521f5d0c2d847bb3580af1&q_lyrics=lose%20yourself&q_artist=eminem&format=jsonp&callback=jsonp_callback&_=1682289240678”
[jquery-3.6.3.min.js:2:83906](https://code.jquery.com/jquery-3.6.3.min.js)
Loading failed for the <script> with source “http://api.musixmatch.com/ws/1.1/track.search?page_size=10&page=1&s_track_rating=desc&callback=jsonp_callback&apikey=5fad2ed714521f5d0c2d847bb3580af1&q_lyrics=lose%20yourself&q_artist=eminem&format=jsonp&callback=jsonp_callback&_=1682289240678”.`